### PR TITLE
Use a unique, shared cache for building Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           push: ${{ env.doPush == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=shared
+          cache-to: type=gha,scope=shared,mode=max
           provenance: false
           # sbom: true


### PR DESCRIPTION
Note: there's [another option](https://stackoverflow.com/questions/74113734/share-gha-docker-cache-among-branches) to read/write to a branch-specific cache while also reading from main. Our "early" layers change very rarely, so using a unique cache should be enough.