### PR TITLE
Rename "testcases" project sub-directory into "tests"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - New Boolean option `run.verbose_validation` (CLI arg: `--verbose-validation`) to help with debugging of validator behaviors [#7](https://github.com/ocamlpro/seacoral/pull/7)
 
 ### Fixed
+- Name of the internal directory where testsuites are exported [#12](https://github.com/ocamlpro/seacoral/pull/12)
 - Detection by the validator of buffer overflows on empty arrays [#6](https://github.com/ocamlpro/seacoral/pull/6)
 - Unnecessary generation by Klee, of tests that violate pre-conditions (`sc_assume`) [#5](https://github.com/ocamlpro/seacoral/pull/5)
 - Handling of NaNs and floating-point literals in test suites [#2](https://github.com/ocamlpro/seacoral/pull/2)

--- a/src/seacoral-main/main.ml
+++ b/src/seacoral-main/main.ml
@@ -307,9 +307,9 @@ let gen_man =
     `Pre "$(mname) $(b,generate)";
     `P "In both cases, $(mname) will perform its test generation job withinh a \
         working directory (named $(i,_sc) by default).  After that, you may find \
-        tests generated for coverage within $(i,_sc/last/testcases/cov), and \
+        tests generated for coverage within $(i,_sc/last/tests/cov), and \
         possibly tests that trigger runtime errors or undefined behaviors in \
-        $(i,_sc/last/testcases/rte).";
+        $(i,_sc/last/tests/rte).";
     `S Cmdliner.Manpage.s_exit_status;
     `S Cmdliner.Manpage.s_bugs;
     `P "Please email bug reports to <seacoral@ocaml.pro>."

--- a/src/seacoral-project/manager.ml
+++ b/src/seacoral-project/manager.ml
@@ -250,7 +250,7 @@ let write_headers_in ~workspace (params: _ project_params) =
 
 let elaborate ~test_repr ({ workspace; codebase; config; label_data;
                             given_entrypoint_name; _ } as preprocessed) =
-  let outdir = workspace.workdir / "testcases" in
+  let outdir = workspace.workdir / "tests" in
   let covdir = outdir / "cov"
   and rtedir = outdir / "rte" in
   let statsdir = workspace.workdir / "stats" in

--- a/src/seacoral-replayer/main.ml
+++ b/src/seacoral-replayer/main.ml
@@ -192,7 +192,7 @@ let play ~wd { dir = _; testcase } =
           Lwt.return false
     end
 
-(** Writes a custom test in the main testcases directory *)
+(** Writes a custom test in the main tests directory *)
 (* TODO: this should just be handed over to the corpus, not written directly
    into the testsuite (as its representation may vary or depend on options and
    choices from another core/project module) *)


### PR DESCRIPTION
This change removes a possible ambiguity about the results that are exported into this directory.