### PR TITLE
Avoid using apt repository for trixie as soon as possible

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,13 +48,15 @@ RUN sudo apt-get update                                                        \
  && rm install-klee.sh
 
 # Install a recent version of CBMC, along with Z3
-# Note: impacts choices of software for apt calls.
+# Restore apt source lists to avoid impacts on choices of software for
+# subsequent apt calls.
 RUN echo >/etc/apt/sources.list.d/trixie.list                                  \
-      'deb http://deb.debian.org/debian trixie main'
-RUN sudo apt-get update                                                        \
+      'deb http://deb.debian.org/debian trixie main'                           \
+ && sudo apt-get update                                                        \
  && sudo apt-get install --yes z3 cbmc                                         \
- && sudo apt-get autoremove --yes                                              \
- && sudo apt-get clean --yes
+ && sudo apt-get clean --yes                                                   \
+ && rm /etc/apt/sources.list.d/trixie.list                                     \
+ && sudo apt-get update
 
 ################################################################################
 


### PR DESCRIPTION
~~C++ development files seem to be missing from final image.~~
Without this cleanup step, reuse of final images is more perilous as many packages automatically get upgraded.