### PR TITLE
Remove creation of `/workdir` in Dockerfile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - New Boolean option `run.verbose_validation` (CLI arg: `--verbose-validation`) to help with debugging of validator behaviors [#7](https://github.com/ocamlpro/seacoral/pull/7)
 
 ### Fixed
+- Usability of Docker images, where `/workdir` is no longer created and the default working directory [#23](https://github.com/OCamlPro/seacoral/pull/23)
 - Internal handling and messaging about malformed CBMC output or unexpected properties in counter-examples [#16](https://github.com/OCamlPro/seacoral/pull/16)
 - Name of the internal directory where testsuites are exported [#12](https://github.com/ocamlpro/seacoral/pull/12)
 - Detection by the validator of buffer overflows on empty arrays [#6](https://github.com/ocamlpro/seacoral/pull/6)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -181,13 +181,3 @@ RUN make -C seacoral reset-versions                                            \
     fi                                                                         \
  && rm -rf seacoral opam                                                       \
            $OPAM_SWITCH_PREFIX/.opam-switch/sources
-
-# Lastly, create a work directory, and make it bindable with both read
-# and write permssions via `--volume <hostdir>:/workdir`.  Also, hack
-# a workaround to volume mounts (note user/group IDs may still be
-# messed up on the host---user namespaces may be a way to solve this).
-RUN sudo mkdir -p /workdir                                                     \
- && sudo chown -R diver:divers /workdir                                        \
- && echo "sudo chown diver:divers /workdir" >> ~/.bashrc
-VOLUME /workdir
-WORKDIR /workdir

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,10 +26,6 @@ The latter command starts a shell in a new container running the
 image; `seacoral` is available as a command-line utility while in this
 shell.
 
-The default working directory in containers derived from the image is
-`/workdir`.  You can pass the options `--volume .:/workdir` to bind
-the current working directory to `/workdir` in the container.
-
 **Warning**: `seacoral` won't be in the `PATH` if a custom shell is
 specified at the end of the `docker run` command.  In this case, you
 can run `eval $(opam env)` (or equivalent) to update the environment


### PR DESCRIPTION
This part in Docker images was confusing and impair their usability. The `sudo`ed  change of directory permissions was also concerning.