### PR TITLE
Fix assumed signature for initialization functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - On the fly reporting and interpretation of CBMC results [#22](https://github.com/ocamlpro/seacoral/pull/22)
 
 ### Fixed
+- Assumed signature of initialization functions: they should not accept any argument [#43](https://github.com/OCamlPro/seacoral/pull/43) (fix for [Issue #39](https://github.com/OCamlPro/seacoral/issues/39))
 - Default maximum number of inputs in CBMC automatically increased [#36](https://github.com/OCamlPro/seacoral/pull/36)
 
 ## 1.0.0 ( 2025-10-30 )

--- a/src/seacoral-c/printer.ml
+++ b/src/seacoral-c/printer.ml
@@ -175,8 +175,7 @@ let pp_named_loc_assoc ppf nla =
 let emit_testcall ~oracle_assessment ~emit_effective_inputs ~entrypoint
     ?init_func ?oracle_func effective_inputs ppf =
   Option.iter begin fun init ->
-    Fmt.pf ppf "(void) %s (%a);@,"
-      init.func_name emit_effective_inputs effective_inputs
+    Fmt.pf ppf "(void) %s ();@," init.func_name
   end init_func;
   match oracle_func, entrypoint.func_rtyp, entrypoint.func_args with
   | None, _, _ ->

--- a/src/seacoral-c/printer.mli
+++ b/src/seacoral-c/printer.mli
@@ -67,8 +67,8 @@ val pp_named_loc_assoc : Format.formatter -> named_loc_assoc -> unit
     a call to the provided [entrypoint] function using the optional functions
     for initialization [init_func] and test oracle [oracle_func].
 
-    If provided, [init_func] should accept the same list of arguments as
-    [entrypoint]; any result it returns is ignored.
+    If provided, [init_func] should not accept any argument; any result it
+    returns is ignored.
 
     If provided, [oracle_func] should accept the same list of arguments as
     [entrypoint], plus an additional parameter with the return type of

--- a/src/seacoral-lib/config.ml
+++ b/src/seacoral-lib/config.ml
@@ -238,8 +238,8 @@ let fixtures_section =
         ~key:"init"
         ~doc:"Initialization function for the entrypoint.  If given, this \
               setting must be the name of a function defined in either the \
-              project codebase or within a file listed in `files`.  Arguments of \
-              this function must also exactly match those of the entrypoint."
+              project codebase or within a file listed in `files`.  This \
+              function must not accept any argument."
         ~runtime:false
         (fun c e -> {c with init = e})
         (fun c -> c.init);

--- a/src/seacoral-luncov/main.ml
+++ b/src/seacoral-luncov/main.ml
@@ -67,10 +67,9 @@ let config_section =
 
 (* --- *)
 
-let emit_initcall project effective_inputs ppf =
+let emit_initcall project ppf =
   Option.iter begin fun (init: Sc_C.Types.func_repr) ->
-    Fmt.pf ppf "(void) %s (%a);@,"
-      init.func_name Sc_C.Printer.pp_vars effective_inputs
+    Fmt.pf ppf "(void) %s ();@," init.func_name
   end project.params.init_func
 
 let args project (fname : string) =
@@ -95,7 +94,7 @@ int main (%a) {
     (Sc_ltest.Framac.Arch.to_fc_string opt.architecture)
     (Sc_sys.File.absname project.label_data.labelized_file)
     Sc_C.Printer.pp_formal_decls args
-    (emit_initcall project args)
+    (emit_initcall project)
     func_name Sc_C.Printer.pp_vars args
 
 (* luncov will work on a link of the label file. *)

--- a/src/seacoral-project/printer.ml
+++ b/src/seacoral-project/printer.ml
@@ -83,6 +83,9 @@ let pp_elaboration_error ppf = function
             pf ppf "function@ `%s''s@ formal@ argument@ `%s'@ has@ an@ \
                     unsupported@ type" func.func_name formal
           end) (Basics.Strings.elements formals)
+  | Unexpected_initialization_function_with_args { func } ->
+      Fmt.pf ppf "Elaboration@ failed:@;initialization@ function@ `%s'@ must@ \
+                  not@ accept@ any@ argument" func.func_name
 
 (* --- *)
 

--- a/src/seacoral-project/types.ml
+++ b/src/seacoral-project/types.ml
@@ -192,5 +192,9 @@ type elaboration_error =
         formals: Basics.Strings.t;                               (* non-empty *)
         func: Sc_C.Types.func_repr;
       }
+  | Unexpected_initialization_function_with_args of
+      {
+        func: Sc_C.Types.func_repr;
+      }
 
 exception ELABORATION_ERROR of elaboration_error

--- a/test/cram/heavy/ok/project-errors.t/bad-fixture.c
+++ b/test/cram/heavy/ok/project-errors.t/bad-fixture.c
@@ -1,0 +1,2 @@
+int foo (int x) { return x; }
+void init (int _) {}

--- a/test/cram/heavy/ok/project-errors.t/bad-fixture.toml
+++ b/test/cram/heavy/ok/project-errors.t/bad-fixture.toml
@@ -1,0 +1,9 @@
+[project]
+files = ["bad-fixture.c"]
+entrypoint = "foo"
+
+[fixtures]
+init = "init"
+
+[run]
+tools = ["klee"]

--- a/test/cram/heavy/ok/project-errors.t/run.t
+++ b/test/cram/heavy/ok/project-errors.t/run.t
@@ -48,3 +48,11 @@ What happens on unsupported coverage criteria?
           SeaCoral does not support the coverage criterion "CACC".
           Supported criteria: [CUSTOM, EMPTY, BC, CB, CC, DC, ELO, FC, GACC, GICC, IDP, IOB, LIMIT, MCC, NCC, RCC, SLO, STMT, WM].
   [124]
+
+What happens on an unexpected initialization function?
+  $ seacoral --config bad-fixture.toml
+  [A]{Sc} Starting to log into `_sc/bad-fixture.c-CC-@1/logs/1.log'
+  [A]{Sc} Initializing working environment...
+  [E]{Sc} Elaboration failed: initialization function `init' must not accept
+          any argument
+  [124]

--- a/test/cram/light/ok/toml.t
+++ b/test/cram/light/ok/toml.t
@@ -170,8 +170,7 @@ Show its contents:
   
   # Initialization function for the entrypoint.  If given, this setting must be
   # the name of a function defined in either the project codebase or within a
-  # file listed in `files`.  Arguments of this function must also exactly match
-  # those of the entrypoint.
+  # file listed in `files`.  This function must not accept any argument.
   # init =
   
   # Oracle function for the entrypoint.  Constraints of `init` also apply, with


### PR DESCRIPTION
Before this change they accepted the same list of arguments as the entrypoint; they now accept no argument.

Closes #39 