### PR TITLE
Fix rights management when creating `diver` in the Docker image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - On the fly reporting and interpretation of CBMC results [#22](https://github.com/ocamlpro/seacoral/pull/22)
 
 ### Fixed
+- Rights management when creating the `diver` user in the Docker image [#46](https://github.com/OCamlPro/seacoral/pull/46) (fix for [Issue #45](https://github.com/OCamlPro/seacoral/issues/45))
 - Default maximum number of inputs in CBMC automatically increased [#36](https://github.com/OCamlPro/seacoral/pull/36)
 
 ## 1.0.0 ( 2025-10-30 )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,11 +64,15 @@ RUN echo >/etc/apt/sources.list.d/trixie.list                                  \
 FROM base AS executable
 
 # Create a dedicated user
-RUN adduser --comment "Reef explorer" diver \
- && adduser --group divers \
- && adduser diver divers \
- && usermod --append --groups sudo diver \
- && echo >>/etc/sudoers "diver ALL = NOPASSWD:ALL"
+COPY <<-EOF /etc/sudoers.d/diver
+  diver ALL=(ALL:ALL) NOPASSWD:ALL
+EOF
+RUN chmod 440 /etc/sudoers.d/diver                                             \
+ && chown root:root /etc/sudoers.d/diver                                       \
+ && if getent passwd 1000; then userdel -r $(id -nu 1000); fi                  \
+ && adduser --uid 1000 --disabled-password --comment "Reef explorer" diver     \
+ && passwd -l diver                                                            \
+ && chown -R diver:diver /home/diver
 USER diver
 WORKDIR /home/diver
 


### PR DESCRIPTION
First attempt at fixing #45.