### PR TITLE
Fix improper handling of partial JSON outputs in `seacoral-cbmc`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - On the fly reporting and interpretation of CBMC results [#22](https://github.com/ocamlpro/seacoral/pull/22)
 
 ### Fixed
+- Improper handling of partial JSON outputs in `seacoral-cbmc` [#67](https://github.com/OCamlPro/seacoral/pull/67)
 - Improper handling of output streams after process termination [#61](https://github.com/OCamlPro/seacoral/pull/61) [#64](https://github.com/OCamlPro/seacoral/pull/64) [#66](https://github.com/OCamlPro/seacoral/pull/66) (fix for [Issue #57](https://github.com/OCamlPro/seacoral/issues/57))
 - Assumed signature of initialization functions: they should not accept any argument [#43](https://github.com/OCamlPro/seacoral/pull/43) (fix for [Issue #39](https://github.com/OCamlPro/seacoral/issues/39))
 - Default maximum number of inputs in CBMC automatically increased [#36](https://github.com/OCamlPro/seacoral/pull/36)

--- a/src/seacoral-cbmc/runner.ml
+++ b/src/seacoral-cbmc/runner.ml
@@ -153,20 +153,19 @@ let uncovered_properties
    returns the corresponding stream of json objects decoded according to
    [encoding]. *)
 let decode_cbmc_output_stream encoding stream =
-  let out, emit = Lwt_stream.create () in
-  Lwt.async begin fun () ->
-    let json = Buffer.create 42 in
-    let parenthesis_depth = ref 0
-    and in_quotes = ref false
-    and junk = ref false in
-    Lwt.map ignore @@
-    Lwt_stream.fold begin fun l escaping ->
+  let json = Buffer.create 42
+  and parenthesis_depth = ref 0
+  and escaping = ref false
+  and in_quotes = ref false
+  and junk = ref false in
+  Lwt_stream.map_list begin fun l ->
+    let rev_res = ref [] in
+    let next_escaping =
       String.fold_left begin fun escaping -> function
         | ',' when !parenthesis_depth = 1 ->                           (* skip *)
             false
         | ']' when !parenthesis_depth = 1 ->
-            junk := true;
-            emit None;                                (* terminate the stream *)
+            junk := true;                              (* terminate the stream *)
             false
         | '{' | '[' as c when not !in_quotes ->
             incr parenthesis_depth;
@@ -181,7 +180,7 @@ let decode_cbmc_output_stream encoding stream =
               Buffer.clear json;
               if !junk
               then Log.debug "Internal@ warning:@ ignored@ garbage@;%s" j
-              else emit @@ Some (Json.read_cbmc_output encoding j)
+              else rev_res := Json.read_cbmc_output encoding j :: !rev_res
             end;
             false
         | '\\' as c when !in_quotes ->
@@ -194,10 +193,11 @@ let decode_cbmc_output_stream encoding stream =
         | c ->
             Buffer.add_char json c;
             false
-      end escaping l
-    end stream false
-  end;
-  out
+      end !escaping l
+    in
+    escaping := next_escaping;
+    List.rev !rev_res
+  end stream
 
 let str_of_mode = function
   | Types.OPTIONS.Cover -> "CBMC_COVER_MODE"


### PR DESCRIPTION
To achieve this we avoid asynchronously converting the output lines stream into a push stream, that may never terminate if the output lines terminate with a trucated JSON object.