### PR TITLE
`seacoral check --init` additionally performs project initialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Next release
 
 ### Added
+- Argument `--initialization` to `seacoral check` to assess proper project initialization after configuration checks [#73](https://github.com/OCamlPro/seacoral/pull/73)
 - New subcommand for replaying tests only [#47](https://github.com/OCamlPro/seacoral/pull/47)
 - The association between labels and tests in the corpus [#53](https://github.com/OCamlPro/seacoral/pull/53)
 - A pretty error message when entrypoints or cover targers are missing from the C code [#52](https://github.com/OCamlPro/seacoral/pull/52)

--- a/src/seacoral-lib/main.ml
+++ b/src/seacoral-lib/main.ml
@@ -174,6 +174,7 @@ let generation_error err =
   raise @@ GENERATION_ERROR err
 
 let initialize_project ~initialization_options ~test_repr ~config =
+  Log.app "Initializing@ working@ environment...";
   Lwt.catch begin fun () ->
     Sc_project.Manager.initialize ~initialization_options ~test_repr ~config
   end begin function
@@ -187,16 +188,20 @@ let initialize_project ~initialization_options ~test_repr ~config =
         Lwt.reraise e
   end
 
+
+let init_check ~project_config ~encoding_params (options: generation_options) =
+  let module Raw_test = (val make_test_repr_module encoding_params) in
+  Lwt.map ignore @@
+  initialize_project
+    ~initialization_options:{ force_preprocess = options.run.force_preprocess }
+    ~test_repr:(module Raw_test)
+    ~config:project_config
+
+
 let generate ~project_config ~encoding_params (options: generation_options) =
-
   let initialization_options =
-    Sc_core.Types.{
-      force_preprocess = options.run.force_preprocess;
-    }
+    { force_preprocess = options.run.force_preprocess }
   in
-
-  Log.app "Initializing@ working@ environment...";
-
   let module Raw_test = (val make_test_repr_module encoding_params) in
   let* project =
     initialize_project ~initialization_options
@@ -311,22 +316,17 @@ let generate ~project_config ~encoding_params (options: generation_options) =
 
   Lwt.return ()
 
+
 let replay ~project_config ~encoding_params (options: replay_options) =
-
   let initialization_options =
-    Sc_core.Types.{
-      force_preprocess = options.replay_config.force_preprocess;
-    }
+    { force_preprocess = options.replay_config.force_preprocess }
   in
-
-  Log.app "Initializing@ working@ environment...";
-
   let module Raw_test = (val make_test_repr_module encoding_params) in
   let* project =
     initialize_project ~initialization_options
       ~test_repr:(module Raw_test)
-      ~config: { project_config with
-                 project_inhibit_store_autostop = true }
+      ~config:{ project_config with
+                project_inhibit_store_autostop = true }
   in
 
   let* validator = Sc_corpus.Validator.setup project.validator in

--- a/src/seacoral-lib/main.mli
+++ b/src/seacoral-lib/main.mli
@@ -29,6 +29,13 @@ val generate
   -> generation_options
   -> unit Lwt.t
 
+(** Performs project initialization only. *)
+val init_check
+  : project_config: Sc_project.Types.project_config
+  -> encoding_params: Sc_values.TYPES.encoding_params
+  -> generation_options
+  -> unit Lwt.t
+
 (** Entrypoint for the replayer. *)
 val replay
   : project_config: Sc_project.Types.project_config

--- a/src/seacoral-main/main.ml
+++ b/src/seacoral-main/main.ml
@@ -11,6 +11,7 @@
 (* If you delete or rename this file, you should add
    'src/sc_main/main.ml' to the 'skip' field in "drom.toml" *)
 
+open Types
 open Sc_core.Types
 open Sc_project.Types
 
@@ -230,7 +231,7 @@ let run
     end
   and* mode =
     match mode with
-    | `Replay | `Config_check as mode ->
+    | `Replay | `Check _ as mode ->
         Lwt.return mode
     | `Generate ->
         config_step begin fun () ->
@@ -241,8 +242,14 @@ let run
     log_config_info config;
     Lwt.catch begin fun () ->
       match mode with
-      | `Config_check ->
+      | `Check { check_initialization = false } ->
           Lwt.return ()
+      | `Check { check_initialization = true } ->
+          Sc_lib.Main.init_check ~project_config ~encoding_params
+            { run = config.run;
+              enable_detailed_stats;
+              strategy = Nothing;
+              print_statistics = args.print_statistics }              (* temp *)
       | `Generate strategy ->
           Sc_lib.Main.generate ~project_config ~encoding_params
             { run = config.run;
@@ -332,9 +339,10 @@ let gen_man =
 
 let load_args ?argv () =
   let open Cmdliner.Cmd in
-  let gen_term = Options.term ~config_sections_that_show_up_as_arguments in
+  let gen_term = Options.gen_term ~config_sections_that_show_up_as_arguments in
+  let chk_term = Cmdliner.Term.product gen_term Options.check_term in
   let generate = Cmdliner.Term.map (fun options -> `Generate options) gen_term
-  and check = Cmdliner.Term.map (fun options -> `Check options) gen_term
+  and check = Cmdliner.Term.map (fun options -> `Check options) chk_term
   and replay = Cmdliner.Term.map (fun options -> `Replay options) gen_term in
   eval_value ~catch:false ?argv @@
   group ~default:generate
@@ -356,7 +364,8 @@ let load_args ?argv () =
                $(b,config initialize) sub-command)")
       (Cmdliner.Term.const `Config_init);
     v (info "check" ~man:gen_man
-         ~doc:"Check configuration and perform initial project initialization")
+         ~doc:"Check configuration and (optionally) perform initial project \
+               initialization")
       check;
     v (info "replay" ~man:gen_man
          ~doc:"Replay the current test suite without starting any test \
@@ -376,9 +385,9 @@ let main ?enable_console_timing ?enable_detailed_stats ?enable_logfile ?argv () 
   | Ok `Ok `Generate args ->
       with_lwt (run ?enable_logfile ?enable_detailed_stats
                   ?enable_console_timing ~mode:`Generate args)
-  | Ok `Ok `Check args ->
+  | Ok `Ok `Check (gen_args, check_options) ->
       with_lwt (run ?enable_logfile ?enable_detailed_stats
-                  ?enable_console_timing ~mode:`Config_check args)
+                  ?enable_console_timing ~mode:(`Check check_options) gen_args)
   | Ok `Ok `Replay args ->
       with_lwt (run ?enable_logfile ?enable_detailed_stats
                   ?enable_console_timing ~mode:`Replay args)

--- a/src/seacoral-main/options.ml
+++ b/src/seacoral-main/options.ml
@@ -54,6 +54,11 @@ let default: options =
     print_statistics = false;
   }
 
+let default_check_options: check_options =
+  {
+    check_initialization = false;
+  }
+
 module Parsing = struct
   open Cmdliner
 
@@ -98,7 +103,22 @@ module Parsing = struct
     |> config_file_term
     |> config_amendments_term ?amendable_sections
 
+  (* --- `check'-specific --- *)
+
+  let check_option check_config_term =
+    let keys = ["initialization"; "init"] in
+    let doc = "Additionally perform project initialization" in
+    let v = Arg.(value & flag & info keys ~doc ~docs) in
+    let set _c b = { check_initialization = b } in
+    Term.(map set check_config_term $ v)
+
+  let check_term =
+    Term.const default_check_options |> check_option
+
 end
 
-let term ~config_sections_that_show_up_as_arguments:amendable_sections =
+let gen_term ~config_sections_that_show_up_as_arguments:amendable_sections =
   Parsing.config_term ~amendable_sections default
+
+let check_term =
+  Parsing.check_term

--- a/src/seacoral-main/options.mli
+++ b/src/seacoral-main/options.mli
@@ -12,8 +12,11 @@ val logs_section: Types.logs_config Sc_config.Section.section
 
 val default: Types.options
 
-val term
+val gen_term
   : config_sections_that_show_up_as_arguments:
       (Sc_config.Section.any_section * [ `with_section_name_prefix
                                        | `without_section_name_prefix ]) list
   -> Types.options Cmdliner.Term.t
+
+val check_term
+  : Types.check_options Cmdliner.Term.t

--- a/src/seacoral-main/types.ml
+++ b/src/seacoral-main/types.ml
@@ -32,3 +32,9 @@ type options =                                (* TODO: split per sub-command  *)
     print_statistics: bool;
     (** When set, print statistics at the end of the run. *)
   }
+
+type check_options =
+  {
+    check_initialization: bool;
+    (** Additionally perform project initialization. *)
+  }

--- a/test/cram/heavy/ok/config-checks.t/dynamic.c
+++ b/test/cram/heavy/ok/config-checks.t/dynamic.c
@@ -1,0 +1,1 @@
+../../common-files/array/dynamic.c

--- a/test/cram/heavy/ok/config-checks.t/dynamic.toml
+++ b/test/cram/heavy/ok/config-checks.t/dynamic.toml
@@ -1,0 +1,1 @@
+../../common-files/array/dynamic.toml

--- a/test/cram/heavy/ok/config-checks.t/run.t
+++ b/test/cram/heavy/ok/config-checks.t/run.t
@@ -1,0 +1,8 @@
+  $ seacoral check --init --config dynamic.toml
+  [A]{Sc} Starting to log into `_sc/dynamic.c-DC-@1/logs/1.log'
+  [A]{Sc} Initializing working environment...
+
+Note: this shall emit a warning (PR pending)
+  $ seacoral check --init --config dynamic.toml --treat-pointer-as-string 'a'
+  [A]{Sc} Starting to log into `_sc/dynamic.c-DC-@2/logs/1.log'
+  [A]{Sc} Initializing working environment...


### PR DESCRIPTION
This will notably be used to check new warnings in #58 .