### PR TITLE
Improve handling of Boolean CLI flags and environment variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Next release
 
 ### Added
+- Ability to interpret `--flag` as `--flag=true` for Boolean CLI flags [#94](https://github.com/OCamlPro/seacoral/pull/94)
 - User documentation of SeaCoral [#85](https://github.com/OCamlPro/seacoral/pull/85)
 - Partial support for constrained pointer fields [#58](https://github.com/OCamlPro/seacoral/pull/58)
 - Argument `--initialization` to `seacoral check` to assess proper project initialization after configuration checks [#73](https://github.com/OCamlPro/seacoral/pull/73)

--- a/src/seacoral-basics/basics.ml
+++ b/src/seacoral-basics/basics.ml
@@ -85,12 +85,12 @@ module PPrt = struct
     let pp_space_separated_ = pp_nodelim ~fsep:" " ~fterm:" " pp_print_string
   end
 
-  let with_oxford_comma pp ppf lst =
+  let with_oxford_comma ?(comb = "and") pp ppf lst =
     let rec aux ?(deep = false) = function
       | [] -> ()
       | [x] -> pp ppf x
-      | [x;y] when not deep -> Fmt.fmt "%a@ and@ %a" ppf pp x pp y
-      | [x;y] when   deep -> Fmt.fmt "%a,@ and@ %a" ppf pp x pp y
+      | [x;y] when not deep -> Fmt.fmt "%a@ %s@ %a" ppf pp x comb pp y
+      | [x;y] when   deep -> Fmt.fmt "%a,@ %s@ %a" ppf pp x comb pp y
       | x :: tl -> Fmt.fmt "%a,@ " ppf pp x; aux ~deep:true tl
     in
     aux lst

--- a/src/seacoral-basics/basics.mli
+++ b/src/seacoral-basics/basics.mli
@@ -83,7 +83,7 @@ module PPrt : sig
     ?fterm:ufmt ->
     ('a * int) pp -> 'a list pp
 
-  (** [with_oxford_comma pp ppf lst] pretty-prints [lst] using [ppf] by
+  (** [with_oxford_comma ~comb pp ppf lst] pretty-prints [lst] using [ppf] by
       enumerating its items and inserting Oxford-style comma.  In particular,
       this function:
 
@@ -91,11 +91,13 @@ module PPrt : sig
 
       - acts like [pp ppf e] if [lst = [e]];
 
-      - prints "[a] and [b]" (without comma) in case [lst = [a;b]];
+      - prints "[a] [comb] [b]" (without comma) in case [lst = [a;b]];
 
       - otherwise prints every element followed by a comma, except for the last
-        that is preceded with "and", as for instance in "a, b, c, and d". *)
-  val with_oxford_comma: 'a pp -> 'a list pp
+        that is preceded with "[comb]", as for instance in "a, b, c, and d".
+
+      [comb] is "and" by default; other sensible use is "or". *)
+  val with_oxford_comma: ?comb:string -> 'a pp -> 'a list pp
 
   (** {3 Helpers for printing string lists} *)
 

--- a/src/seacoral-config/eztoml.ml
+++ b/src/seacoral-config/eztoml.ml
@@ -404,7 +404,7 @@ let print_as_rst_file ppf ((main_key, schema): string * 'a schema) =
       (if row.runtime then "[runtime knob]" else "[project-defining knob]")
       (pp_spec_doc_comments ~prefix:"") row.spec
     ) schema;
-  Fmt.pf ppf "@]@;@;"     
+  Fmt.pf ppf "@]@;@;"
 
 (** Cmdliner helpers *)
 
@@ -432,13 +432,16 @@ let cmdline_flag
   let info_ = Arg.info ?env:(Option.map (Cmd.Env.info ?docs) env) ?docs in
   function
   | Valued ->
-      Arg.(value & opt (some bool_conv) None & info_ keys ~doc)
+      Arg.(value & opt ~vopt:(Some tt) (some bool_conv) None &
+           info_ keys ~doc)
   | Positive { keys; doc = kdoc } ->
       let doc = match kdoc with `Same -> doc | `Alt doc -> doc in
-      Arg.(value & vflag None [Some      tt , info_ (ikeys keys) ~doc])
+      Arg.(Term.map (fun x -> if x then Some tt else None) &
+           value & flag & info_ (ikeys keys) ~doc)
   | Negative { keys; doc = kdoc } ->
       let doc = match kdoc with `Same -> doc | `Alt doc -> doc in
-      Arg.(value & vflag None [Some (neg tt), info_ (ikeys keys) ~doc])
+      Arg.(Term.map (fun x -> if x then Some (neg tt) else None) &
+           value & flag & info_ (ikeys keys) ~doc)
   | Both { pos_keys; pos_doc; neg_keys; neg_doc } ->
       let pos_doc = match pos_doc with `Same -> doc | `Alt doc -> doc
       and neg_doc = match neg_doc with `Same -> doc | `Alt doc -> doc

--- a/src/seacoral-config/eztoml.ml
+++ b/src/seacoral-config/eztoml.ml
@@ -462,11 +462,23 @@ let cmdline_flag
              [Some      tt , info (ikeys pos_keys) ~doc:pos_doc ?docs;
               Some (neg tt), info (ikeys neg_keys) ~doc:neg_doc ?docs])
 
+let loose_bool_conv =
+  let bool_parser s =
+    match String.lowercase_ascii s with
+    | "" | "false" | "no" | "n" | "0" -> Ok false
+    | "true" | "yes" | "y" | "1" -> Ok true
+    | s ->
+        PPrt.string_to Result.error "invalid value %S, expected one of %a." s
+          (PPrt.with_oxford_comma ~comb:"or" @@ Fmt.fmt "%S")
+          ["true"; "false"; "yes"; "no"; "y"; "n"; "1"; "0"; ""]
+  in
+  Cmdliner.Arg.conv' (bool_parser, Format.pp_print_bool)
+
 let bool_cmdline_flag
   : keys:string list -> ?env:string -> doc:string -> ?docs:string -> bool doc ->
     cmdline_flag_type -> bool option Cmdliner.Term.t =
   cmdline_flag
-    ~bool_conv:Cmdliner.Arg.bool ~tt:true ~neg:(not)
+    ~bool_conv:loose_bool_conv ~tt:true ~neg:(not)
 
 (* --- *)
 
@@ -571,7 +583,7 @@ module Toml_conv = struct
   and tfloat  e = TFloat  e and nfloat  e = NodeFloat  e
   and tstring e = TString e and nstring e = NodeString e
 
-  let bool         = value_conv Arg.bool   tbool
+  let bool         = value_conv loose_bool_conv tbool
   and int          = value_conv Arg.int    tint
   and float        = value_conv Arg.float  tfloat
   and string       = value_conv Arg.string tstring

--- a/src/seacoral-lib/config.ml
+++ b/src/seacoral-lib/config.ml
@@ -33,7 +33,7 @@ let run_section =
         ~doc:"Force preprocessing, even if it has already been performed."
         ~default:default.force_preprocess
         ~runtime:true
-        ~as_flag:(Positive { keys = `Same; doc = `Same })
+        ~as_flag:Valued
         (fun c f -> {c with force_preprocess = f})
         (fun c -> c.force_preprocess);
       string
@@ -116,7 +116,7 @@ let run_section =
               by default)."
         ~env:"VERBOSE_VALIDATION"
         ~runtime:true       (* CHECKME: validator recompilation may be needed *)
-        ~as_flag:(Positive { keys = `Same; doc = `Same })
+        ~as_flag:Valued
         ~default:default.verbose_validation
         (fun c b -> { c with verbose_validation = b })
         (fun c -> c.verbose_validation);

--- a/src/seacoral-main/options.ml
+++ b/src/seacoral-main/options.ml
@@ -69,13 +69,16 @@ module Parsing = struct
 
   let docs = Manpage.s_common_options
 
+  let bool_valued_flag =
+    Arg.(opt ~vopt:true bool false)
+
   let clean_start_term config_term =
     let keys = ["clean-start"] in
     let doc =
       "Remove the project with the same hash before starting its analysis \
        (default: false)"
     in
-    let v = Arg.(value & flag & info keys ~doc ~docs) in
+    let v = Arg.(value & bool_valued_flag & info keys ~doc ~docs) in
     let set c f = {c with clean_start = f} in
     Term.(map set config_term $ v)
 
@@ -97,7 +100,7 @@ module Parsing = struct
   let statistics config_term =
     let keys = ["show-statistics"; "stats"] in
     let doc = "Print statistics of the current run" in
-    let v = Arg.(value & flag & info keys ~doc ~docs) in
+    let v = Arg.(value & bool_valued_flag & info keys ~doc ~docs) in
     let set c f = {c with print_statistics = f} in
     Term.(map set config_term $ v)
 
@@ -113,7 +116,7 @@ module Parsing = struct
   let check_option check_config_term =
     let keys = ["initialization"; "init"] in
     let doc = "Additionally perform project initialization" in
-    let v = Arg.(value & flag & info keys ~doc ~docs) in
+    let v = Arg.(value & bool_valued_flag & info keys ~doc ~docs) in
     let set _c b = { check_initialization = b } in
     Term.(map set check_config_term $ v)
 

--- a/test/cram/heavy/ok/config-checks.t/run.t
+++ b/test/cram/heavy/ok/config-checks.t/run.t
@@ -15,3 +15,11 @@
   [W]{Sc_project} Ignoring `string' specification for pointer field `a' in
                   `struct t' that is already constrained as an array with size
                   field `n'.
+
+Take this opportunity to check that `--init` and `--clean-start` are
+valued Boolean flags:
+  $ seacoral check --init=true --config dynamic.toml
+  [A]{Sc} Starting to log into `_sc/dynamic.c-DC-@3/logs/2.log'
+  [A]{Sc} Initializing working environment...
+  $ seacoral check --init false --config dynamic.toml --clean-start true
+  [A]{Sc} Starting to log into `_sc/dynamic.c-DC-@4/logs/1.log'


### PR DESCRIPTION
Before these changes, it was not possible to pair a Boolean CLI flag with an environment variable. The included changes bring this feature, along with the ability to shorten valued Boolean CLI arguments so `--flag` is equivalent to `--flag true`.