### PR TITLE
Add reporting of global buffer overflows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Next release
 
+### Added
+- Reporting of global buffer overflows [#99](https://github.com/OCamlPro/seacoral/pull/99)
+
 ### Fixed
 - Improper harness for KLEE, when a constrained field is an array of non-primitive cells [#97](https://github.com/OCamlPro/seacoral/pull/97)
 

--- a/src/seacoral-corpus/iO.ml
+++ b/src/seacoral-corpus/iO.ml
@@ -15,18 +15,20 @@ open Types
 (** {2 RTE "identifiers"} *)
 
 let print_sanitizer_error_summary = function
-  | Heap_buffer_overflow addr ->
-      Basics.PPrt.asprintf "rte:heap-buffer-overflow\t0x%Lx" addr
-  | Invalid_memory_address addr ->
-      Basics.PPrt.asprintf "rte:invalid-memory-address\t0x%Lx" addr
-  | Arithmetic_error addr ->
-      Basics.PPrt.asprintf "rte:arithmetic-error\t0x%Lx" addr
+  | Heap_buffer_overflow { pc } ->
+      Basics.PPrt.asprintf "rte:heap-buffer-overflow\t0x%Lx" pc
+  | Global_buffer_overflow { pc } ->
+      Basics.PPrt.asprintf "rte:global-buffer-overflow\t0x%Lx" pc
+  | Invalid_memory_address { pc } ->
+      Basics.PPrt.asprintf "rte:invalid-memory-address\t0x%Lx" pc
+  | Arithmetic_error { pc } ->
+      Basics.PPrt.asprintf "rte:arithmetic-error\t0x%Lx" pc
 
 let print_cover_summary ints =
   Basics.PPrt.asprintf
     "cover\t%a"
     (fun fmt l -> List.iter (fun i -> Fmt.int fmt i; Fmt.string fmt "\t") l)
-    (Basics.Ints.elements ints) 
+    (Basics.Ints.elements ints)
 
 let print_oracle_fail () = "oracle-fail\t"
 
@@ -47,18 +49,21 @@ let scan_list ic =
   loop Basics.Ints.empty
 
 let scan_summary (ic: Scanf.Scanning.in_channel) =
+  let rte err = Triggering_RTE err in
   Scanf.bscanf ic "%s@\t" begin function
     | "rte:heap-buffer-overflow" ->
-        Scanf.bscanf ic "0x%Lx"
-          (fun addr -> Triggering_RTE (Heap_buffer_overflow addr))
+        Scanf.bscanf ic "0x%Lx" (fun pc -> rte @@ Heap_buffer_overflow { pc })
+    | "rte:global-buffer-overflow" ->
+        Scanf.bscanf ic "0x%Lx" (fun pc -> rte @@ Global_buffer_overflow { pc })
     | "rte:invalid-memory-address" ->
-        Scanf.bscanf ic "0x%Lx"
-          (fun addr -> Triggering_RTE (Invalid_memory_address addr))
+        Scanf.bscanf ic "0x%Lx" (fun pc -> rte @@ Invalid_memory_address { pc })
     | "rte:arithmetic-error" ->
-        Scanf.bscanf ic "0x%Lx"
-          (fun addr -> Triggering_RTE (Arithmetic_error addr))
-    | "cover" -> Covering_label (scan_list ic)
-    | "oracle-fail" -> Oracle_failure
+        Scanf.bscanf ic "0x%Lx" (fun pc -> rte @@ Arithmetic_error { pc })
+    | "cover" ->
+        Covering_label (scan_list ic)
+    | "oracle-fail" ->
+        Oracle_failure
     | key ->
-        raise (Scanf.Scan_failure (Fmt.str "unknown sanitizer error key %S" key))
+        Fmt.kstr (fun s -> raise (Scanf.Scan_failure s))
+          "unknown sanitizer error key %S" key
   end

--- a/src/seacoral-corpus/printer.ml
+++ b/src/seacoral-corpus/printer.ml
@@ -46,12 +46,14 @@ let pp_oracle_failures_info ppf { num_fails_gen; num_fails_imported; _ } =
 (** {2 RTE "identifiers"} *)
 
 let pp_sanitizer_error_summary ppf = function
-  | Heap_buffer_overflow addr ->
-      Fmt.pf ppf "heap-buffer-overflow at 0x%Lx" addr
-  | Invalid_memory_address addr ->
-      Fmt.pf ppf "invalid-memory-address at 0x%Lx" addr
-  | Arithmetic_error addr ->
-      Fmt.pf ppf "arithmetic error at 0x%Lx" addr
+  | Heap_buffer_overflow { pc } ->
+      Fmt.pf ppf "heap-buffer-overflow at pc=0x%Lx" pc
+  | Global_buffer_overflow { pc } ->
+      Fmt.pf ppf "global-buffer-overflow at pc=0x%Lx" pc
+  | Invalid_memory_address { pc } ->
+      Fmt.pf ppf "invalid-memory-address at pc=0x%Lx" pc
+  | Arithmetic_error { pc } ->
+      Fmt.pf ppf "arithmetic error at pc=0x%Lx" pc
 
 let pp_test_outcome ppf = function
   | Covering_label i ->

--- a/src/seacoral-corpus/types.ml
+++ b/src/seacoral-corpus/types.ml
@@ -74,9 +74,10 @@ and test_outcome =
   | Oracle_failure                              (** The test fails the oracle *)
 
 and sanitizer_error_summary =
-  | Heap_buffer_overflow of int64
-  | Invalid_memory_address of int64                                   (* SEGV *)
-  | Arithmetic_error of int64
+  | Heap_buffer_overflow of { pc: int64 }
+  | Global_buffer_overflow of { pc: int64 }
+  | Invalid_memory_address of { pc: int64 }                           (* SEGV *)
+  | Arithmetic_error of { pc: int64 }
 
 (** Revalidation/replay *)
 

--- a/src/seacoral-corpus/validator.ml
+++ b/src/seacoral-corpus/validator.ml
@@ -396,11 +396,13 @@ let remove_log log =
 let sanitizer_summary_parsers =
   [
     mk_parser "SUMMARY: AddressSanitizer: heap-buffer-overflow (%_s@+0x%Lx)"
-      (fun loc -> Heap_buffer_overflow loc);
+      (fun pc -> Heap_buffer_overflow { pc });
+    mk_parser "SUMMARY: AddressSanitizer: global-buffer-overflow (%_s@+0x%Lx)"
+      (fun pc -> Global_buffer_overflow { pc });
     mk_parser "SUMMARY: AddressSanitizer: SEGV (%_s@+0x%Lx)"
-      (fun loc -> Invalid_memory_address loc);
+      (fun pc -> Invalid_memory_address { pc });
     mk_parser "SUMMARY: AddressSanitizer: FPE (%_s@+0x%Lx)"
-      (fun loc -> Arithmetic_error loc);
+      (fun pc -> Arithmetic_error { pc });
   ]
 
 let scan_sanitizer_lines ~log:(module Log: Ez_logs.T) lines =


### PR DESCRIPTION
Test still missing for this new kind of detected RTE (typically an overflow on a `const` array).